### PR TITLE
Put database credentials in separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.php

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 currently only basic function is working
 
+# Installation
+
+1. Clone this repository (e.g. `git clone https://github.com/fadkeabhi/CLIPBOARD`)
+2. Copy config.sample.php to config.php (`cp config.sample.php config.php`)
+3. Set up your own database credentials in config.php
+
 # to do
 
 - [ ] improve style

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ currently only basic function is working
 1. Clone this repository (e.g. `git clone https://github.com/fadkeabhi/CLIPBOARD`)
 2. Copy config.sample.php to config.php (`cp config.sample.php config.php`)
 3. Set up your own database credentials in config.php
+4. Import `clips.sql` into the database (e.g. `mysql -uroot clipboard < clips.sql`)
 
 # to do
 

--- a/config.sample.php
+++ b/config.sample.php
@@ -1,0 +1,5 @@
+<?php
+$servername = "localhost";
+$username = "root";
+$password = "";
+$dbname = "clipboard";

--- a/db.php
+++ b/db.php
@@ -1,9 +1,5 @@
 <?php
-$servername = "localhost";
-$username = "root";
-$password = "";
-$dbname = "clipboard";
-
+require_once 'config.php';
 // Create connection
 $conn = new mysqli($servername, $username, $password, $dbname);
 // Check connection


### PR DESCRIPTION
In the current version the database credentials (username etc.) are in the same file: `db.php`

If someone has a root password, wants to use different database name, etc. they have to change that file. Since `db.php` is under version control this is less than ideal.

This PR splits it out into a separate `config.php`, provides a sample file, and instructions on how to set it up for new installations.