### PR TITLE
Feature: add button to copy clipboard text

### DIFF
--- a/clipboard.js
+++ b/clipboard.js
@@ -1,0 +1,28 @@
+const clips = document.getElementsByClassName('clip');
+let buttonLastCopied;
+
+for (const clip of clips) {
+	const button = document.createElement("button");
+	setClipboardEmoji(button);
+	button.addEventListener('click', () => {
+		navigator.clipboard.writeText(clip.children[2].childNodes[0].data) // assumption: the second child element is always the clip content
+		.then(() => {
+			setTickEmoji(button);
+		}, (err) => {
+			alert('Error copying text: ', err);
+		});
+	});
+	clip.children[2].appendChild(button);
+}
+
+function setClipboardEmoji(button) {
+	button.innerHTML = String.fromCodePoint(0x1F4CB); // 📋 (Clipboard emoji)
+}
+
+function setTickEmoji(button) {
+	if (buttonLastCopied) {
+		setClipboardEmoji(buttonLastCopied);
+	}
+	button.innerHTML = String.fromCodePoint(0x2714); // ✔️ (Tick emoji)
+	buttonLastCopied = button;
+}

--- a/index.php
+++ b/index.php
@@ -140,5 +140,6 @@ $limit = $_GET['show-limit'] ?? 5;
         <br>
 
         <script src="./themeswitch.js"></script>
+        <script src="./clipboard.js"></script>
     </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,9 @@ form.textBox{
   min-height: 5ch;
 }
 
+.clip button {
+  float: right;
+}
 
 /*text related styles*/
 #mainHeading{


### PR DESCRIPTION
This PR adds a copy button to each clip for easy copying.

Implements https://github.com/fadkeabhi/CLIPBOARD/issues/41

Features: 

- A new clipboard button at the right of every clip
- On button click, text of the clip is copied to system clipboard using [Async Clipboard API](https://www.w3.org/TR/clipboard-apis/#dom-clipboard-writetext)
- UI: Graphical feedback (📋 -> ✔️) after the text has been successfully copied

Preview: 

| Before copying | After copying |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/103271100/195153147-bbfc3325-8a01-4c04-9ea2-4a8a5cf23e75.png) | ![image](https://user-images.githubusercontent.com/103271100/195153608-a76e7327-adf5-40b1-ac70-5097e76069db.png) |




