### PR TITLE
Fix Bug about number of clips shown 

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,7 +46,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // limit of number of clips displayed
-$limit = $_GET['show-limit'] ?? 5;
+$limit = $_GET['show-limit'] ?? '5';
 ?>
 
 <!doctype html>


### PR DESCRIPTION
Fixes #61 
![ClipBoard](https://user-images.githubusercontent.com/66111954/198897669-3f6abb9a-82b2-4dd3-86ae-f6a0c86a3058.PNG)
Displays 5 clips by default even when there are 10 clips.